### PR TITLE
correct syntax error in database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  adapter: postgreql
+  adapter: postgresql
   pool: 5
   timeout: 5000
 


### PR DESCRIPTION
corrected syntax error in database.yml
 -- typo on adapter
